### PR TITLE
No deprecated jquery

### DIFF
--- a/addon/components/search-with-modifiers/search-box/component.js
+++ b/addon/components/search-with-modifiers/search-box/component.js
@@ -6,6 +6,7 @@ import Token from '../../../models/token';
 import KEY from '../../../utils/keycodes';
 import { tokenize, setCursor } from '../../../utils/search';
 import { typeOf } from '@ember/utils';
+import $ from 'jquery';
 
 const doNothing = function() {};
 
@@ -36,8 +37,8 @@ export default Component.extend({
   didInsertElement() {
     this._super(...arguments);
     run.schedule('afterRender', this, function() {
-      this._mainInput = this.$('.search-box-input');
-      this._background = this.$('.search-box-hints');
+      this._mainInput = $(this.element).find('.search-box-input');
+      this._background = $(this.element).find('.search-box-hints');
       this._mouseWheelListener = run.bind(this, 'onMouseScroll');
       this._mainInput.on('mousewheel DOMMouseScroll', this._mouseWheelListener); // maybe to do with custom events ?
 

--- a/addon/components/search-with-modifiers/search-modifiers/component.js
+++ b/addon/components/search-with-modifiers/search-modifiers/component.js
@@ -4,6 +4,7 @@ import { scheduleOnce } from '@ember/runloop';
 import { set, get, computed, observer } from '@ember/object';
 import { typeOf } from '@ember/utils';
 import { A } from '@ember/array';
+import $ from 'jquery';
 
 const doNothing = function() {};
 
@@ -17,7 +18,7 @@ export default Component.extend({
     scheduleOnce('afterRender', this, function() {
       let currentIndex = this.get('currentIndex');
       if(currentIndex === -1 || !this.element) return;
-      let $listItem = this.$('div.search-modifier').eq(currentIndex);
+      let $listItem = $(this.element).find('div.search-modifier').eq(currentIndex);
       let $list = $listItem.parent();
 
       let scroll = $list.scrollTop();
@@ -69,7 +70,7 @@ export default Component.extend({
 
   didInsertElement() {
     this._super(...arguments);
-    if(this.get('focused')) this.$('.list-keyboard-navigator').focus();
+    if(this.get('focused')) $(this.element).find('.list-keyboard-navigator').focus();
   },
 
   actions: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-search-with-modifiers",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A search box that can be configured to allow autocompleting modifier lists",
   "keywords": [
     "ember-addon",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "ember-cli-babel": "^7.1.2",
     "ember-cli-htmlbars": "^3.0.0",
     "ember-copy": "^1.0.0",
+    "ember-list-keyboard-navigator": "^0.0.3",
     "ember-truth-helpers": "^2.1.0"
   },
   "devDependencies": {
@@ -42,7 +43,6 @@
     "ember-cli-uglify": "^2.1.0",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-export-application-global": "^2.0.0",
-    "ember-list-keyboard-navigator": "^0.0.1",
     "ember-load-initializers": "^1.1.0",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-mocha": "^0.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3308,10 +3308,10 @@ ember-export-application-global@^2.0.0:
   dependencies:
     ember-cli-babel "^6.0.0-beta.7"
 
-ember-list-keyboard-navigator@^0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/ember-list-keyboard-navigator/-/ember-list-keyboard-navigator-0.0.1.tgz#33eb370cb4a7da42f1f2d32e223ffe6aef4ab924"
-  integrity sha512-EudDqMZj2QCUfD7c90UhY4cBRoeNFlZrLApTQlFM3r1kbh6agWUkh9G8AzPPe9WN5CxDzkeV1mq+0ey/UfEZHg==
+ember-list-keyboard-navigator@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/ember-list-keyboard-navigator/-/ember-list-keyboard-navigator-0.0.3.tgz#26530a74a95cf76bb6d46fd4f2ab494d93be3ad6"
+  integrity sha512-7tPUEFrMLIoO2OKAKo/3Q9FprDoI01TV7QyW3wk/j1p0amkq0vc2+AoIcSXitIe8uKgrOaAgH83mcZS+D7Km4g==
   dependencies:
     "@ember/jquery" "^0.5.2"
     ember-cli-babel "^7.1.2"


### PR DESCRIPTION
Calls to `this.$()` are deprecated as of Ember 3.9